### PR TITLE
Map host port 13000 to container port 13000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - "ssv:/data"
     ports:
-      - "13000"
+      - "13000:13000"
       - 12000/udp
     environment:
       CONFIG_PATH: ./config.yml


### PR DESCRIPTION
Due to the issue https://github.com/bloxapp/ssv/issues/289

SSV checks host port 13000, so it cannot be random assigned to a host port 