### PR TITLE
Enable log level in advanced settings

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -6,5 +6,6 @@ yq e -i '.eth2.BeaconNodeAddr = strenv(BEACON_NODE_ADDR)' ./config.yml
 yq e -i '.eth1.ETH1Addr = strenv(ETH1ADDR)' ./config.yml
 yq e -i '.eth1.RegistryContractAddr = strenv(REGISTRY_CONTRACT_ADDR)' ./config.yml
 yq e -i '.OperatorPrivateKey = strenv(OPERATOR_PRIVATE_KEY)' ./config.yml
+yq e -i '.global.LogLevel = strenv(LOG_LEVEL)' ./config.yaml
 
 BUILD_PATH=/go/bin/ssvnode make start-node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       ETH1ADDR: "ws://goerli-geth.dappnode:8546"
       REGISTRY_CONTRACT_ADDR: "0x687fb596F3892904F879118e2113e1EEe8746C2E"
       OPERATOR_PRIVATE_KEY: ""
+      LOG_LEVEL: info
       EXTRA_OPTS: ""
 volumes:
   ssv: {}


### PR DESCRIPTION
Adding ability to change log granularity, as described in docs: https://docs.ssv.network/operators/installation-operator-1/installation-operator#5.-create-configuration-file

Can be particularly useful when trying to debug issues with "debug" log level.