### PR TITLE
Remove Prysm Prater Dependency + Fix License Typo

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -12,7 +12,7 @@
     "Eduardo Antuña <edu@dappnode.io> (https://github.com/eduadiez)"
   ],
   "categories": ["Blockchain", "ETH2.0"],
-  "license": "GLP-3.0",
+  "license": "GPL-3.0",
   "links": {
     "explorer": "https://explorer.ssv.network/",
     "homepage": "https://ssv.network/"
@@ -25,7 +25,6 @@
     "url": "https://github.com/dappnode/DAppNodePackage-SSV/issues"
   },
   "dependencies": {
-    "goerli-geth.dnp.dappnode.eth": "latest",
-    "prysm-prater.dnp.dappnode.eth": "latest"
+    "goerli-geth.dnp.dappnode.eth": "latest"
   }
 }


### PR DESCRIPTION
removed Prysm prater dependency since auto-update remains an issue and updates packages set to not update when called for via upgrades or new install of packages requiring a dependent package.  And this version of SSV still is incompatible with Prysm past v2.0.5, they claim prysm broke something i will follow up on that with James @ prysmatic labs.  Also fixed License type typo. 

Former line 29 for reinsertion when the incompatibility is resolved.
```
 "prysm-prater.dnp.dappnode.eth": "latest"
```