### PR TITLE
replace prater dependency,

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -25,6 +25,7 @@
     "url": "https://github.com/dappnode/DAppNodePackage-SSV/issues"
   },
   "dependencies": {
-    "goerli-geth.dnp.dappnode.eth": "latest"
+    "goerli-geth.dnp.dappnode.eth": "latest",
+    "prysm-prater.dnp.dappnode.eth": "latest"
   }
 }


### PR DESCRIPTION
replace prater dependency, the latest prysm and ssv now work together again so im reverting a previous change from the previous non compatible versions