### PR TITLE
Publish major version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Publish
-        run: npx @dappnode/dappnodesdk publish patch --dappnode_team_preset --timeout 1h
+        run: npx @dappnode/dappnodesdk publish major --dappnode_team_preset --timeout 1h
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEVELOPER_ADDRESS: "0xf35960302a07022aba880dffaec2fdd64d5bf1c1"

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssv.dnp.dappnode.eth",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "upstreamVersion": "v1.3.3",
   "upstreamRepo": "bloxapp/ssv",
   "upstreamArg": "UPSTREAM_VERSION",


### PR DESCRIPTION
As the package has been greatly modified, the version to publish must be tagged as a major change. Therefore, version `2.0.0` is set to the package