### PR TITLE
Set package version to 0.1.0

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssv.dnp.dappnode.eth",
-  "version": "2.0.0",
+  "version": "0.1.0",
   "upstreamVersion": "v1.3.3",
   "upstreamRepo": "bloxapp/ssv",
   "upstreamArg": "UPSTREAM_VERSION",


### PR DESCRIPTION
Package with ENS `ssv.dnp.dappnode.eth` has not been published yet, so the starting version should be `0.1.0`