### PR TITLE
Use new upstream format

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,9 +1,18 @@
 {
   "name": "ssv.dnp.dappnode.eth",
   "version": "0.1.1",
-  "upstreamVersion": "v1.3.4",
-  "upstreamRepo": "bloxapp/ssv",
-  "upstreamArg": "UPSTREAM_VERSION",
+  "upstream":[
+    {
+      "repo": "ssvlabs/ssv",
+      "version": "v1.3.4",
+      "arg": "OPERATOR_UPSTREAM_VERSION"
+    },
+    {
+      "repo": "ssvlabs/ssv-dkg",
+      "version": "v2.1.0",
+      "arg": "DKG_UPSTREAM_VERSION"
+    }
+  ],
   "architectures": ["linux/amd64"],
   "shortDescription": "Secret Shared Validator for Ethereum mainnet",
   "description": "SSV.network is a decentralized ETH staking network enabling the distributed operation of an Ethereum validator. The network allows both users and operators to diversify staking risks, optimize performance, and promote decentralization across the Ethereum consensus layer.",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: operator
       args:
-        UPSTREAM_VERSION: v1.3.4
+        OPERATOR_UPSTREAM_VERSION: v1.3.4
     restart: unless-stopped
     volumes:
       - operator-data:/data/operator

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,6 +1,6 @@
-ARG UPSTREAM_VERSION
+ARG OPERATOR_UPSTREAM_VERSION
 
-FROM bloxstaking/ssv-node:${UPSTREAM_VERSION}
+FROM bloxstaking/ssv-node:${OPERATOR_UPSTREAM_VERSION}
 
 # Use apt
 RUN apt-get update && \


### PR DESCRIPTION
Use new upstream format to keep both services up-to-date:

`OPERATOR_UPSTREAM_VERSION` and `DKG_UPSTREAM_VERSION`