### PR TITLE
Use Debian commands in operator Dockerfile

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -3,15 +3,10 @@ ARG OPERATOR_UPSTREAM_VERSION
 FROM bloxstaking/ssv-node:${OPERATOR_UPSTREAM_VERSION}
 
 # Use apt (Debian) --> SSV operator v1.3.6+
-# RUN apt-get update && \
-#     apt-get install -y curl jq ruby openssl && \
-#     apt-get clean && \
-#     rm -rf /var/lib/apt/lists/* && \
-#     mkdir -p /data/operator/config
-
-# Use apk (Alpine)
-RUN apk update && \
-    apk add --no-cache curl jq ruby openssl && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl jq ruby openssl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
     mkdir -p /data/operator/config
 
 COPY node-config.yml /ssv-node/config/raw-node-config.yml


### PR DESCRIPTION
Operator `v1.3.6+` uses Debian as base image, instead of Alpine. The commands need to be updated accordingly